### PR TITLE
refactor: use employee prisma model

### DIFF
--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -16,10 +16,10 @@ export default defineEventHandler(async (event) => {
   if (!parsed.success) { setResponseStatus(event, 400); return fail('Invalid payload', 'VALIDATION_ERROR', 400) }
 
   const { name, email, password } = parsed.data
-  const exists = await prisma.user.findUnique({ where: { email } })
+  const exists = await prisma.employee.findUnique({ where: { email } })
   if (exists) { setResponseStatus(event, 409); return fail('Email in use', 'EMAIL_EXISTS', 409) }
 
   const passwordHash = await bcrypt.hash(password, 10)
-  const user = await prisma.user.create({ data: { name, email, passwordHash } })
-  return ok({ id: user.id })
+  const employee = await prisma.employee.create({ data: { name, email, passwordHash } })
+  return ok({ id: employee.id })
 })


### PR DESCRIPTION
## Summary
- update registration API to use `prisma.employee`

## Testing
- `npx eslint server/api/auth/register.post.ts` (warning: File ignored because no matching configuration was supplied)
- `npx tsc -p tsconfig.json --noEmit` (error: Object literal may only specify known properties)
- `npx tsc server/api/auth/register.post.ts --noEmit` (errors: missing Prisma client, zod modules)
- `node -e "const {PrismaClient}=require('@prisma/client');const prisma=new PrismaClient();console.log('employee' in prisma);console.log(Object.keys(prisma.employee).slice(0,5));"` (failed: Cannot find module '.prisma/client/default')
- `npx prisma generate` (failed: 403 Forbidden when downloading Prisma engines)


------
https://chatgpt.com/codex/tasks/task_e_68c62a549a8c83268c182e3ecc357c70