### PR TITLE
refactor: use response wrapper in API handlers

### DIFF
--- a/server/api/employees/index.get.ts
+++ b/server/api/employees/index.get.ts
@@ -1,9 +1,10 @@
 import { PrismaClient } from '@prisma/client'
 import { EmployeeTransformer } from '../../transformers/employee.transformer'
 import { defineEventHandler } from 'h3'
+import { ok } from '../../../server/utils/responseWrapper'
 const prisma = new PrismaClient()
 
 export default defineEventHandler(async () => {
   const employees = await prisma.employee.findMany({ where: { isDeleted: false } })
-  return { success: true, data: EmployeeTransformer.collection(employees) }
+  return ok(EmployeeTransformer.collection(employees))
 })


### PR DESCRIPTION
## Summary
- use ok helper in employee list API
- return ok/fail helpers in auth/me API

## Testing
- `pnpm build` *(fails: Nuxt Build Error: Could not resolve "../../.nuxt/imports" from "app/pages/login.vue?vue&type=script&setup=true&lang.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68c633df3ac883268307b9525bc1416c